### PR TITLE
Retry x times on failure, use timeouts

### DIFF
--- a/test_shit.sh
+++ b/test_shit.sh
@@ -30,17 +30,15 @@ cd \$(dirname \$0)
 	flaky=0
 	ret=0
 	try=0
+	output=""
 
-	$*
+	output=\$($*)
 	ret=\$?
 
 	# Retry as needed
 	while [ \$ret -ne 0 ] && [ \$try -lt ${MAX_RETRIES} ]; do
-		if [ "x$VERBOSE" = "xtrue" ]; then
-			print_yellow "Delaying and retrying: $*\n"
-		fi
 		sleep ${RETRY_DELAY};
-		$*
+		output=\$($*)
 		ret=\$?
 
 		try=\$(( \$try + 1 ))
@@ -53,6 +51,7 @@ cd \$(dirname \$0)
 
 	echo \$ret > ret
 	echo \$flaky > flaky
+	echo "\$output (\$try retries)"
 } | sponge
 echo \$(( \$(date +%s) - \${_start} )) > runtime
 _EOF_
@@ -206,5 +205,5 @@ if [ "x$total_ret" != "x0" ]; then
 else
 	print_green "All ok!\n"
 fi
-echo "$total_ret of $total tests failed. Run-time: $_duration seconds. Flaky, but passing tests: $total_flaky"
+echo "$total_ret of $total tests failed. Run-time: $_duration seconds. $total_flaky flaky, but passing tests."
 exit $total_ret

--- a/util.sh
+++ b/util.sh
@@ -13,9 +13,16 @@ print_red() {
 		echo -en "$*"
 	fi
 }
+print_yellow() {
+	if [ "x$COLOR" != "xNO"  ]; then
+		echo -en "\033[33m$*\033[0m";
+	else
+		echo -en "$*"
+	fi
+}
 
 eat_it() {
-	http -ph GET "$1" | awk -v arg1="$2" -v arg2="$3" -v url="$1" -v verbose=$VERBOSE '
+	http --timeout $TIMEOUT -ph GET "$1" | awk -v arg1="$2" -v arg2="$3" -v url="$1" -v verbose=$VERBOSE '
 /^HTTP\/1.1/ {
 	status=$2
 }
@@ -94,7 +101,7 @@ check_ssl() {
 }
 
 check_mixed() {
-	_out=$(! wget -p $1 --delete-after 2>&1| grep http://)
+	_out=$(! wget -T $TIMEOUT -p $1 --delete-after 2>&1| grep http://)
 	ret=$?
 	if [  "x$ret" = "x0" ]; then
 		print_green "OK     "


### PR DESCRIPTION
Adds 3 retries per failing check (with 5s sleep between), and counts it as flaky if it passes on one of the retries. Also adds pretty short timeouts to `wget` and `http` calls (currently 2s), since anything slower than that (after x retries) is practically broken.

Hoping this will make a few more of the "weird" responses we see in production instead return as flaky after retries.